### PR TITLE
Make background element configurable

### DIFF
--- a/source/focusManager.js
+++ b/source/focusManager.js
@@ -153,7 +153,8 @@ function restrictFocus(modal, focusedElement) {
 
 // modal, the element in which to contain focus
 // focusElement (optional), the element inside the modal to focus when opening
-function captureModalFocus(modal, focusElement) {
+// backgroundElement (optional), All focus events within this element are redirected to the modal. Defaults to document
+function captureModalFocus(modal, focusElement, backgroundElement) {
 
 	// without a modal there is nothing to capture
 	if (!modal) {
@@ -174,7 +175,7 @@ function captureModalFocus(modal, focusElement) {
 	// The focus event does not bubble
 	// however it can be captured on an ancestor element
 	// by setting useCapture to true
-	var eventListenerContext = document;
+	var eventListenerContext = backgroundElement || document;
 	var eventListenerArguments = ["focus", focusCallback, true];
 
 	// Save the eventListener data in the state object so it can be removed later

--- a/test/mainSpec.js
+++ b/test/mainSpec.js
@@ -395,11 +395,17 @@ describe("captureModalFocus", function () {
 			expect(insider).toBe(document.activeElement);
 		});
 
-		it("should set the state object", function () {
+		it("should set the state object with document when no backgroundElement is specified", function () {
 			captureModalFocus();
 
 			expect(state.eventListenerContext).toBe(document);
 			expect(state.eventListenerArguments).toEqual(["focus", jasmine.any(Function), true]);
+		});
+
+		it("should set the state object to backgroundElement when it is specified", function () {
+			captureModalFocus(modal, insider, root);
+
+			expect(state.eventListenerContext).toBe(root);
 		});
 
 		it("should release the previous modal capture", function () {


### PR DESCRIPTION
Some modal dialogs only prevent user interaction with a part of the page. Add the background element as an argument to `capture` to support this use case.
